### PR TITLE
Ported changes for EmbeddedProtoDescriptor in branch 2.x to 3.x

### DIFF
--- a/generator/support/TypeDefinitions.py
+++ b/generator/support/TypeDefinitions.py
@@ -243,6 +243,14 @@ class MessageDefinition(TypeDefinition):
     def get_type(self):
         return self.scope.get_scope_str()
 
+    def get_path(self):
+        path = [self.get_name()]
+        node = self.scope
+        while (node.parent):
+            path.append(node.parent.name)
+            node = node.parent
+        return '.'.join(reversed(path))
+
     def print_template_data(self, indent):
         print(indent + "Message definition: " + self.name)
         if self.nested_msg_definitions:

--- a/generator/templates/TypeDefMsg.h
+++ b/generator/templates/TypeDefMsg.h
@@ -57,6 +57,11 @@ class {{ typedef.get_name() }} final: public ::EmbeddedProto::MessageInterface
 
     ~{{ typedef.get_name() }}() override = default;
 
+    struct EmbeddedProtoDescriptor {
+        static constexpr char kMessageName[] = "{{ typedef.get_name() }}";
+        static constexpr char kFullTypeName[] = "{{ typedef.get_path() }}";
+    };
+
     {% for enum in typedef.nested_enum_definitions %}
     {{ enum.render(environment)|indent(4) }}
 


### PR DESCRIPTION
Fancom-develop was based of Master branch, not rc-3.0.0. However, the code we wrote seems to depend on rc-3.0.0. This will hopefully update the fancom-develop branch to the rc-3.0.0 standard.
Alternatively, we could re-create the fancom-develop branch.